### PR TITLE
GoogleAuthVersion "0.20.0" => "0.21.1"

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val SpannerVersion = "1.52.0"
   // Keep in sync with Akka gRPC
   val GrpcVersion = "1.30.2"
-  val GoogleAuthVersion = "0.20.0"
+  val GoogleAuthVersion = "0.21.1"
 
   object Compile {
     val akkaActorTyped = "com.typesafe.akka" %% "akka-actor-typed" % AkkaVersion


### PR DESCRIPTION
The spanner library does conflict with other libraries for GCP products (it is PubSub in my case). Starting this pull request more like a conversation around the conflicting libraries and possible resolution.

Problem description: an Akka Cluster application is using Google PubSub (v1.108.0) by adding Spanner Persistence library one of the underlying libraries are conflicting on classes level. Classes in Spanner Persistence library are created by compiling protobuf files rather than referencing. So, the conflict between google.auth reference and same classes replicated within.

To me the problem is more general than just these versions of the library. Isn't there an inherited problem of such conflicts we protobuf files are compiled into an library? What might be the thought-process around the problem and possible solution?